### PR TITLE
Link to qpp-measures-data

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -37,7 +37,7 @@ class App extends React.PureComponent {
           <h2>Explore the full API with our interactive reference.</h2>
           <p className="usa-font-lead">Want more detail? Check out our <a href="https://qpp-submissions-sandbox.navapbc.com/api-explorer">interactive API reference</a> for an exhaustive list of endpoints with example request and response payloads. Test out what else you can do!</p>
           <h2>Understand and integrate with measures data.</h2>
-          <p className="usa-font-lead">Full Improvement Activity and Advancing Care Information measures data is available as an <a href="https://github.com/CMSgov/qpp-measures-data">NPM module</a>. We also provide a JSON schema to explain the structure of ACI, IA, and Quality measures data.</p>
+          <p className="usa-font-lead">A complete list of ACI (Advancing Care Information) and IA (Improvement Activity) measures is available in the <a href="https://github.com/CMSgov/qpp-measures-data">qpp-measures-data repository</a>. Each measure contains a description and additional information around attestation and scoring requirements. Additionally, you can integrate with the qpp-measures-data NPM module to import measures data into your own code base and work with it programatically.</p>
           <h3>All done?</h3>
           <p>Return to the <a href="https://qpp.cms.gov/resources/developers">QPP Developer Resources</a>.</p>
         </div>


### PR DESCRIPTION
https://jira.cms.gov/browse/QPPA-365

Goal is to link to `qpp-measures-data` and give a little context for what someone can find there. I've specified that IA and ACI measures data is there in full and that the schema for quality, IA and ACI measures is there. 

Screenshot of how it looks
<img width="825" alt="screen shot 2017-03-09 at 4 58 42 pm" src="https://cloud.githubusercontent.com/assets/869654/23772664/d1bbc350-04e9-11e7-906a-ac51325a4c1a.png">

Reviewers: @kencheeto @lucasmbrown-usds @shashashasha 
