### PR TITLE
QPPA-616: add google groups link to dev-docs

### DIFF
--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -43,7 +43,7 @@ class App extends React.PureComponent {
           <p className="ds-text--lead">Demystify how the aggregate score for a complex performance category like ACI is calculated. Updating and correcting performance data is also easy - avoid losing time by solving issues as they arise, rather than reacting months later.</p>
           <a className="ds-c-button ds-c-button--primary" href="/qpp-submissions-docs/advanced-tutorial">Start the advanced tutorial</a>
 
-          <h2 className="ds-h2">Explore the full API with our interactive reference.</h2>
+          <h2 className="ds-h2">Explore the API with our interactive reference.</h2>
           <p className="ds-text--lead">Want more detail? Check out our <a href="https://qpp-submissions-sandbox.navapbc.com/api-explorer">interactive API reference</a> for an exhaustive list of endpoints with example request and response payloads. Test out what else you can do!</p>
 
           <h2 className="ds-h2">Understand and integrate with measures data.</h2>
@@ -52,6 +52,9 @@ class App extends React.PureComponent {
           <h2 className="ds-h2">View the API Reference</h2>
           <p className="ds-text--lead">The technical reference information for the Submissions API and sample submission data are available <a href="/qpp-submissions-docs/schemas">here</a>. This will let you validate your own submission formatting in XML or JSON.</p>
 
+          <h2 className="ds-h2">Need help or have feedback?</h2>
+          <p className="ds-text--lead">Join our <a href="https://groups.google.com/forum/#!forum/qpp-apis">Google Group</a>, where you can interact with other developers and ask questions, find answers and share experiences using the API. If you need further help, you can <a href="mailto:QPP@cms.hhs.gov">contact</a> the QPP Service Center.</p>
+             
           <h3 className="ds-h3">All done?</h3>
           <p>Return to the <a href="https://qpp.cms.gov/resources/developers">QPP Developer Resources</a>.</p>
         </div>


### PR DESCRIPTION
Added section about google groups to this page: https://cmsgov.github.io/qpp-submissions-docs/