### PR TITLE
Adding a CONTRIBUTING.md for new contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@
 
 ## Merging to master
 
-Before merging to master, PR should have been approved following code review and the last commit should have a big green checkmark from CI.
+Before merging to master, PR should have been approved following code review.
 
 1. Do a squash merge:
 


### PR DESCRIPTION
Basically a clone of file in qpp-submissions-api but removed requirement for JIRA URLs (as this repo is public and links to our JIRA instance seems like not a great idea) though still included the direction to put the JIRA issue number in as that felt safer but still relevant. Also removed note about test plan and deployment information, as the test plan seems not relevant for a repo on documentation and deployment information is covered in README.md