### PR TITLE
Make public sandbox more explicit

### DIFF
--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -43,8 +43,8 @@ class App extends React.PureComponent {
           <p className="ds-text--lead">Demystify how the aggregate score for a complex performance category like ACI by seeing an example of how it might be calculated. Updating and correcting performance data is also easy - avoid losing time by solving issues as they arise, rather than reacting months later.</p>
           <a className="ds-c-button ds-c-button--primary" href="/qpp-submissions-docs/advanced-tutorial">Start the advanced tutorial</a>
 
-          <h2 className="ds-h2">Explore the API with our interactive reference.</h2>
-          <p className="ds-text--lead">Want more detail? Check out our <a href="https://qpp-submissions-sandbox.navapbc.com/api-explorer">interactive API reference</a> for an exhaustive list of endpoints with example request and response payloads. This is the best place to test the most current Submissions API and scoring behavior. Test out what else you can do!</p>
+          <h2 className="ds-h2">Explore the API using the public sandbox.</h2>
+          <p className="ds-text--lead">The public sandbox API allows you to test integrating with the API before the reporting period begins - without making a real submission to QPP. You can access the public sandbox API endpoints via the command line using the URL 'https://qpp-submissions-sandbox.navapbc.com/v1/'. Check out the <a href="https://qpp-submissions-sandbox.navapbc.com/api-explorer">interactive API reference</a> for an exhaustive list of endpoints with example request and response payloads.</p>
 
           <h2 className="ds-h2">Understand and integrate with measures data.</h2>
           <p className="ds-text--lead">A complete list of ACI (Advancing Care Information) and IA (Improvement Activity) measures is available in the <a href="https://github.com/CMSgov/qpp-measures-data">qpp-measures-data repository</a>. Each measure contains a description and additional information around attestation and scoring requirements. Additionally, you can integrate with the qpp-measures-data NPM module to import measures data into your own code base and work with it programatically.</p>


### PR DESCRIPTION
Genevieve and I were on a call with athenahealth last week, including members of their development team, and they did not realize there is a public sandbox available. They thought they could only access the API via the Swagger UI. Since qpp-submissions-docs is the main portal for developer documentation, I want to update the copy around the interactive API reference to make it more explicit that you can access the API endpoints via the command line directly.