### PR TITLE
QPPA-853 make copy changes about private beta in dev docs

### DIFF
--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -50,7 +50,7 @@ class App extends React.PureComponent {
 
           <h2 className="ds-h2">Participate in the Submissions API Private Beta</h2>
           <p className="ds-text--lead">The QPP Submissions API will be in private beta from July 2017 through December 2017. During this period, we will collect participants' feedback and make refinements before we open the API for public use.</p>
-          <p className="ds-text--lead">At this time, the private beta is open only to 2017 CMS-approved Qualified Registries ("registries") and Qualified Clinical Data Registries ("QCDRs").  To participate, you will need to request an API key by contacting the Quality Payment Program Service Center at <a href="mailto:qpp@cms.hhs.gov">QPP@cms.hhs.gov</a>.</p>
+          <p className="ds-text--lead">At this time, the private beta is open only to 2017 CMS-approved Qualified Registries ("registries") and Qualified Clinical Data Registries ("QCDRs").  To participate, you will need to request an API key by contacting the Quality Payment Program Service Center at <a href="mailto:qpp@cms.hhs.gov?subject=Request%20API%20Key%20for%20Submissions%20API%20Beta">QPP@cms.hhs.gov</a>.</p>
           <a className="ds-c-button ds-c-button--primary" href="/qpp-submissions-docs/privatebeta">Learn more about the private beta</a>
 
           <h2 className="ds-h2">Understand and integrate with measures data.</h2>

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -49,8 +49,8 @@ class App extends React.PureComponent {
           <p className="ds-text--lead">The public sandbox API allows you to test integrating with the API before the reporting period begins - without making a real submission to QPP. You can access the public sandbox API endpoints via the command line using the URL 'https://qpp-submissions-sandbox.navapbc.com/v1/'. Check out the <a href="https://qpp-submissions-sandbox.navapbc.com/api-explorer">interactive API reference</a> for an exhaustive list of endpoints with example request and response payloads.</p>
 
           <h2 className="ds-h2">Participate in the Submissions API Private Beta</h2>
-          <p className="ds-text--lead">The QPP Submissions API is currently in private beta, and will be open from July 2017 through December 2017. During this period, we will collect participants' feedback and make refinements before we open the API for public use.</p>
-          <p className="ds-text--lead">At this time, the private beta is open only to 2017 CMS-approved Qualified Registries ("registries") and Qualified Clinical Data Registries ("QCDRs").  To participate, you will need to request an API key using <a href="https://goo.gl/forms/85W7sk8s6Sf0fOsN2">this form</a>.</p>
+          <p className="ds-text--lead">The QPP Submissions API will be in private beta from July 2017 through December 2017. During this period, we will collect participants' feedback and make refinements before we open the API for public use.</p>
+          <p className="ds-text--lead">At this time, the private beta is open only to 2017 CMS-approved Qualified Registries ("registries") and Qualified Clinical Data Registries ("QCDRs").  To participate, you will need to request an API key by contacting the Quality Payment Program Service Center at <a href="mailto:qpp@cms.hhs.gov">QPP@cms.hhs.gov</a>.</p>
           <a className="ds-c-button ds-c-button--primary" href="/qpp-submissions-docs/privatebeta">Learn more about the private beta</a>
 
           <h2 className="ds-h2">Understand and integrate with measures data.</h2>

--- a/src/components/privatebeta.jsx
+++ b/src/components/privatebeta.jsx
@@ -22,15 +22,23 @@ export default class Beta extends React.PureComponent {
             <li>Receive the preliminary score for a submission, based on the finalized policy</li>
           </ul>
           </p>
-          <p class="ds-text">The private beta is different from the public sandbox in that it is authenticated and accepts personally identifiable information (e.g. Taxpayer Identification Numbers and National Provider Identifiers). This mirrors the general availability Submissions API, which will be released in mid-December, so that integrators can better prepare to integrate with the Submissions API for real-time usage.</p>
+          <p class="ds-text">The private beta is different from the public sandbox in that it is authenticated and accepts personally identifiable information (e.g. Taxpayer Identification Numbers). This mirrors the general availability Submissions API, which will be released in mid-December, so that integrators can better prepare to integrate with the Submissions API for official usage.</p>
 
           <h2 className="ds-h2">Authentication</h2>
           <p class="ds-text">Authenticate your account when using the API by including your secret API key in the header of every request to the API using the key value pair: <code>"Authentication":"Bearer [YOUR API TOKEN]"</code>.</p>
-          <p class="ds-text">Learn more about requesting an API key below. Your API key carries many privileges, so be sure to keep them secret! Do not share your API keys in publicly accessible areas such as GitHub, client-side code, and so forth.</p>
+          <p class="ds-text">Learn more about requesting an API key below. Your API key carries many privileges, so be sure to keep it secret! Do not share your API key in publicly accessible areas such as GitHub, client-side code, and so forth. Within your organization, limit access to only the staff person/s who will embed it in your software.</p>
           <p class="ds-text">API requests without authentication will fail.</p>
 
           <h2 className="ds-h2">Permissions</h2>
-          <p class="ds-text">The Submissions API has three types of objects: submissions, measurement sets, and measurements. A submission object contains any performance data submitted on behalf of a single MIPS-eligible clinician or practice. A measurement set object represents a set of performance data related to one specific category (Quality, Improvement Activities, or Advancing Care Information), and is tied to a submission object. A measurement object represents one single data point related to a specific measure in a given category, and is tied to a measurement set object.</p>
+          <p class="ds-text">The Submissions API has three types of objects: 
+            <ul>
+            <li>submissions</li>
+            <li>measurement sets</li>
+            <li>measurements</li>
+            </ul>
+          </p>
+          
+          <p class="ds-text">A submission object contains any performance data submitted on behalf of a single MIPS-eligible clinician, practice or group. A measurement set object represents a set of performance data related to one specific category (Quality, Improvement Activities, or Advancing Care Information), and is tied to a submission object. A measurement object represents one single data point related to a specific measure in a given category, and is tied to a measurement set object.</p>
 
           <h2 className="ds-h2">Creating, reading, updating and deleting data</h2>
           <p class="ds-text">In general, you can read, update and delete data that you yourself have submitted, regardless of whether you are a clinician/practice or an organization. However, only a MIPS-eligible doctor or practice can edit a submission object for their own performance data. Organizations, such as Qualified Registries and Qualified Clinical Data Registries, can create measurement sets and add them to any submission object. In other words, MIPS-eligible doctors and practices can make POST /submissions/ requests, but organizations can only make POST /measurement-sets/ and POST /measurements/ requests.</p>
@@ -39,12 +47,14 @@ export default class Beta extends React.PureComponent {
           <p class="ds-text">If you are associated with a third party vendor, you can only view scores based on the data you've submitted. In the future, there will be a way for MIPS-eligible clinicians and practices to grant organizations additional permissions so that the organization can get a final score that represents all data submitted on the clinician/practice's behalf (not just based on data they've submitted).</p>
 
           <h2 className="ds-h2">How to request an API key</h2>
-          <p class="ds-text">At this time, the private beta is open only to 2017 CMS-approved Qualified Registries ("registries") and Qualified Clinical Data Registries ("QCDRs").  To request an API key, fill out <a href="https://goo.gl/forms/85W7sk8s6Sf0fOsN2">this form</a>.</p>
+          <p class="ds-text">At this time, the private beta is open only to 2017 CMS-approved Qualified Registries ("registries") and Qualified Clinical Data Registries ("QCDRs").  Request an API key by contacting the Quality Payment Program Service Center at <a href="mailto:QPP@cms.hhs.gov">QPP@cms.hhs.gov</a>.</p>
           <p class="ds-text">We will verify that you are associated with a 2017 CMS-approved registry or QCDR, and manually generate an API key for you. Your API key permits authenticated access to the Submissions API private beta, and will expire November 1, 2017. After this date, you will be able to request a new API key through an automated, self-service process.</p>
           <p class="ds-text">When you get this key:
           <ul>
             <li>Keep it secure. Treat your API key like you would treat any account password.</li>
             <li>Copy and save it for your records. For security reasons, we will only re-send the API key to you once. After that, you will need to contact <a href="mailto:qpp@cms.hhs.gov">QPP@cms.hhs.gov</a> to request a new API key.</li>
+            <li>Do not share your API key with anyone outside your organization.</li>
+            <li>Within your organization, limit access to only the staff person/s who will embed it in your software.</li>
           </ul>
           </p>
 
@@ -55,7 +65,7 @@ export default class Beta extends React.PureComponent {
           <h2 className="ds-h2">Where to go for support</h2>
           <p class="ds-text">
             <ul>
-              <li>Request access to the private beta by completing <a href="https://goo.gl/forms/85W7sk8s6Sf0fOsN2">this form</a>.</li>
+              <li>Request an API key for the private beta by contacting the Quality Payment Program Service Center at <a href="mailto:QPP@cms.hhs.gov">QPP@cms.hhs.gov</a>.</li>
               <li>Contact the <a href="mailto:qpp@cms.hhs.gov">QPP Service Center</a>.</li>
               <li>If you're a developer, visit the <a href="https://cmsgov.github.io/qpp-submissions-docs/">API documentation</a>.</li>
             </ul>

--- a/src/components/privatebeta.jsx
+++ b/src/components/privatebeta.jsx
@@ -47,12 +47,12 @@ export default class Beta extends React.PureComponent {
           <p class="ds-text">If you are associated with a third party vendor, you can only view scores based on the data you've submitted. In the future, there will be a way for MIPS-eligible clinicians and practices to grant organizations additional permissions so that the organization can get a final score that represents all data submitted on the clinician/practice's behalf (not just based on data they've submitted).</p>
 
           <h2 className="ds-h2">How to request an API key</h2>
-          <p class="ds-text">At this time, the private beta is open only to 2017 CMS-approved Qualified Registries ("registries") and Qualified Clinical Data Registries ("QCDRs").  Request an API key by contacting the Quality Payment Program Service Center at <a href="mailto:QPP@cms.hhs.gov">QPP@cms.hhs.gov</a>.</p>
+          <p class="ds-text">At this time, the private beta is open only to 2017 CMS-approved Qualified Registries ("registries") and Qualified Clinical Data Registries ("QCDRs").  Request an API key by contacting the Quality Payment Program Service Center at <a href="mailto:QPP@cms.hhs.gov?subject=Request%20API%20Key%20for%20Submissions%20API%20Beta">QPP@cms.hhs.gov</a>.</p>
           <p class="ds-text">We will verify that you are associated with a 2017 CMS-approved registry or QCDR, and manually generate an API key for you. Your API key permits authenticated access to the Submissions API private beta, and will expire November 1, 2017. After this date, you will be able to request a new API key through an automated, self-service process.</p>
           <p class="ds-text">When you get this key:
           <ul>
             <li>Keep it secure. Treat your API key like you would treat any account password.</li>
-            <li>Copy and save it for your records. For security reasons, we will only re-send the API key to you once. After that, you will need to contact <a href="mailto:qpp@cms.hhs.gov">QPP@cms.hhs.gov</a> to request a new API key.</li>
+            <li>Copy and save it for your records. For security reasons, we will only re-send the API key to you once. After that, you will need to contact <a href="mailto:qpp@cms.hhs.gov?subject=Request%20API%20Key%20for%20Submissions%20API%20Beta">QPP@cms.hhs.gov</a> to request a new API key.</li>
             <li>Do not share your API key with anyone outside your organization.</li>
             <li>Within your organization, limit access to only the staff person/s who will embed it in your software.</li>
           </ul>
@@ -65,8 +65,7 @@ export default class Beta extends React.PureComponent {
           <h2 className="ds-h2">Where to go for support</h2>
           <p class="ds-text">
             <ul>
-              <li>Request an API key for the private beta by contacting the Quality Payment Program Service Center at <a href="mailto:QPP@cms.hhs.gov">QPP@cms.hhs.gov</a>.</li>
-              <li>Contact the <a href="mailto:qpp@cms.hhs.gov">QPP Service Center</a>.</li>
+              <li>Request an API key for the private beta by contacting the Quality Payment Program Service Center at <a href="mailto:QPP@cms.hhs.gov?subject=Request%20API%20Key%20for%20Submissions%20API%20Beta">QPP@cms.hhs.gov</a>.</li>
               <li>If you're a developer, visit the <a href="https://cmsgov.github.io/qpp-submissions-docs/">API documentation</a>.</li>
             </ul>
           </p>


### PR DESCRIPTION
-google form is no longer being used to collect requests for api key; updated copy to let reader know to email QPP service center to request one
-made some other small copy changes, as per jonathan sullivan's comments here: https://confluence.cms.gov/pages/viewpage.action?pageId=68731604