### PR TITLE
Fix sandbox link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ These are static tutorials designed to illustrate some common workflows when com
 
 It's also useful to describe the data being submitted and updated through the API, so these data schemas list the fields belonging to each resource type as well as some supplementary details about concepts like scoring.
 
-References to [qpp-measures-data](https://github.com/CMSgov/qpp-measures-data), the [interactive API reference](https://qpp-submissions-sandbox.navapbc.com/api-explorer), and the Google Group are also listed.
+References to [qpp-measures-data](https://github.com/CMSgov/qpp-measures-data), the [interactive API reference](https://qpp-submissions-sandbox.navapbc.com/), and the Google Group are also listed.
 
 ## Development
 

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -46,7 +46,7 @@ class App extends React.PureComponent {
           <a className="ds-c-button ds-c-button--primary" href="/qpp-submissions-docs/advanced-tutorial">Start the advanced tutorial</a>
 
           <h2 className="ds-h2">Explore the API using the public sandbox.</h2>
-          <p className="ds-text--lead">The public sandbox API allows you to test integrating with the API before the reporting period begins - without making a real submission to QPP. You can access the public sandbox API endpoints via the command line using the URL 'https://qpp-submissions-sandbox.navapbc.com/v1/'. Check out the <a href="https://qpp-submissions-sandbox.navapbc.com/api-explorer">interactive API reference</a> for an exhaustive list of endpoints with example request and response payloads.</p>
+          <p className="ds-text--lead">The public sandbox API allows you to test integrating with the API before the reporting period begins - without making a real submission to QPP. You can access the public sandbox API endpoints via the command line using the URL 'https://qpp-submissions-sandbox.navapbc.com/v1/'. Check out the <a href="https://qpp-submissions-sandbox.navapbc.com/">interactive API reference</a> for an exhaustive list of endpoints with example request and response payloads.</p>
 
           <h2 className="ds-h2">Participate in the Submissions API Private Beta</h2>
           <p className="ds-text--lead">The QPP Submissions API is currently in private beta, and will be open from July 2017 through December 2017. During this period, we will collect participants' feedback and make refinements before we open the API for public use.</p>

--- a/src/components/privatebeta.jsx
+++ b/src/components/privatebeta.jsx
@@ -55,7 +55,6 @@ export default class Beta extends React.PureComponent {
           <h2 className="ds-h2">Where to go for support</h2>
           <p class="ds-text">
             <ul>
-              <li>Request access to the private beta by completing <a href="https://goo.gl/forms/85W7sk8s6Sf0fOsN2">this form</a>.</li>
               <li>Contact the <a href="mailto:qpp@cms.hhs.gov">QPP Service Center</a>.</li>
               <li>If you're a developer, visit the <a href="https://cmsgov.github.io/qpp-submissions-docs/">API documentation</a>.</li>
             </ul>

--- a/src/components/tutorials/advanced-tutorial.jsx
+++ b/src/components/tutorials/advanced-tutorial.jsx
@@ -55,7 +55,7 @@ class AdvancedTutorial extends React.PureComponent {
           <h1 className="ds-h1">Advanced API Tutorial</h1>
           <p>In the <a href="/qpp-submissions-docs/tutorial">first tutorial</a> we covered how to create a submission, add a measurement set with IA category performance data, and retrieve the score in three different API requests. This time we're going to build on the previous tutorial and look at creating a submission with embedded ACI performance data in one request, go through ACI scoring and how measures compose a score, and see how to update a measure with new info (all while running into a problem along the way). All of these examples serve to illustrate how the Submissions API can make it easier to react to and fix issues that arise.</p>
           <p>
-          Like the previous tutorial, please remember that the score calculation may be inaccurate until the API is finalized. The <a href="https://qpp-submissions-sandbox.navapbc.com/api-explorer">interactive API</a> will always return the latest score calculation.</p>
+          Like the previous tutorial, please remember that the score calculation may be inaccurate until the API is finalized. The <a href="https://qpp-submissions-sandbox.navapbc.com/">interactive API</a> will always return the latest score calculation.</p>
           <h2 className="ds-h2" id="submitting-with-performance-data">
             <a
               className="tutorial-header-link"
@@ -258,7 +258,7 @@ class AdvancedTutorial extends React.PureComponent {
           <p><em>Disclaimer:</em> Scoring is subject to change, based on periodic policy updates, eligibility reviews, and technical integration developments.</p>
           <h3>Next steps</h3>
           <p>While we've used each API endpoint, we're far from having used every kind of API action. These tutorials have used <code>POST</code>, <code>PATCH</code>, and <code>GET</code> - there are also <code>PUT</code> and <code>DELETE</code> for each of the three resources we worked with.</p>
-          <p>The tutorials have shown how requests can be strung together to complete complex workflows in minutes rather than months. For more technical detail about these API requests, check out our interactive <a href="https://qpp-submissions-sandbox.navapbc.com/api-explorer">API reference</a>.</p>
+          <p>The tutorials have shown how requests can be strung together to complete complex workflows in minutes rather than months. For more technical detail about these API requests, check out our interactive <a href="https://qpp-submissions-sandbox.navapbc.com/">API reference</a>.</p>
         </div>
         <div className="temp-grid-half">
           <TechnicalDetailsPane

--- a/src/components/tutorials/basic-tutorial.jsx
+++ b/src/components/tutorials/basic-tutorial.jsx
@@ -54,7 +54,7 @@ class BasicTutorial extends React.PureComponent {
         <div className="temp-grid-half">
           <h1 className="ds-h1">API Tutorial</h1>
           <p>The Submissions API is an easy way to manage your performance data with CMS. Performance data is organized into <em>submissions</em>, which can have many <em>measurements</em>. Measurements within a submission are also grouped by category (e.g. Improvement Activities) and submission method (e.g. CMS web interface) into <em>measurement sets</em>.</p>
-          <p>Since the API and scoring calculations are still being finalized, please note that some numbers (especially scoring) may be inaccurate. The <a href="https://qpp-submissions-sandbox.navapbc.com/api-explorer">interactive API</a> will always reflect the latest design.</p>
+          <p>Since the API and scoring calculations are still being finalized, please note that some numbers (especially scoring) may be inaccurate. The <a href="https://qpp-submissions-sandbox.navapbc.com/">interactive API</a> will always reflect the latest design.</p>
           <p>Let's walk through an example of how we might submit performance data!</p>
           <h2 className="ds-h2" id="creating-a-submission">
             <a
@@ -175,7 +175,7 @@ class BasicTutorial extends React.PureComponent {
           <h3>Next steps</h3>
           <p>Explore a more complex and powerful workflow in our <a href="/qpp-submissions-docs/advanced-tutorial">advanced tutorial</a>.</p>
           <a className="ds-c-button ds-c-button--primary ds-c-button--big" href="/qpp-submissions-docs/advanced-tutorial">Start the advanced tutorial</a>
-          <p>To learn more about what else you can do with the API, visit our <a href="https://qpp-submissions-sandbox.navapbc.com/api-explorer">API reference</a>.</p>
+          <p>To learn more about what else you can do with the API, visit our <a href="https://qpp-submissions-sandbox.navapbc.com/">API reference</a>.</p>
         </div>
         <div className="temp-grid-half">
           <TechnicalDetailsPane


### PR DESCRIPTION
We removed the `/api-explorer` path in the last deployment.

Reviewer: @ivanang 