### PR TITLE
updates old /v1/x urls to /x

### DIFF
--- a/src/components/tutorials/advanced-tutorial.jsx
+++ b/src/components/tutorials/advanced-tutorial.jsx
@@ -69,7 +69,7 @@ class AdvancedTutorial extends React.PureComponent {
           <p>The request payload on the right can be harder to read, but it contains the same info as below formatted exactly as it's sent through the API. Check it out then click the button!</p>
           <InlineApiExample
             verb="POST"
-            url="/v1/submissions"
+            url="/submissions"
             params={
               <tbody>
                 <tr><td>Program Name</td>
@@ -112,7 +112,7 @@ class AdvancedTutorial extends React.PureComponent {
           <p>If we wanted to <em>update</em> the existing submission we could use a <code>PUT</code> (full record update) or <code>PATCH</code> (partial record update) request, but since we're trying to show how we can create a new submission with measurement data embedded, let's use a different TIN and try again.</p>
           <InlineApiExample
             verb="POST"
-            url="/v1/submissions"
+            url="/submissions"
             params={
               <tbody>
                 <tr><td>Program Name</td>
@@ -171,7 +171,7 @@ class AdvancedTutorial extends React.PureComponent {
          <p>The scoring is more complicated for ACI measures, so we'll spend more time going through that.</p>
           <InlineApiExample
             verb="GET"
-            url="/v1/submissions/:id/score"
+            url="/submissions/:id/score"
             button={
               <button
                 className="ds-c-button ds-c-button--primary"
@@ -205,7 +205,7 @@ class AdvancedTutorial extends React.PureComponent {
           <p>So far we've only been creating new submission and measurement set records. Since performance data can change over time, we'll need to update CMS. Let's update an existing measure with new performance data! In addition to a measurement <code>ID</code>, we need to provide the measurement set <code>ID</code> and the measure <code>ID</code>. For the performance data itself, let's update the <code>ACI_HIE_1</code> proportion from 10 out of 100 to 50 out of 100 and see how that affects our score.</p>
           <InlineApiExample
             verb="PATCH"
-            url="/v1/measurements/:id"
+            url="/measurements/:id"
             params={
               <tbody>
                 <tr><td>Measurement ID</td>
@@ -243,7 +243,7 @@ class AdvancedTutorial extends React.PureComponent {
           </h2>
           <InlineApiExample
             verb="GET"
-            url="/v1/submissions/:id/score"
+            url="/submissions/:id/score"
             button={
               <button
                 className="ds-c-button ds-c-button--primary"

--- a/src/components/tutorials/basic-tutorial.jsx
+++ b/src/components/tutorials/basic-tutorial.jsx
@@ -64,11 +64,11 @@ class BasicTutorial extends React.PureComponent {
                 Creating a new submission
             </a>
           </h2>
-          <p>We need to create a <em>submission</em> first. We can do that by asking the API to create a submission record in the CMS database. In API terms, this means making a <code>POST</code> (synonym for <em>create</em>) request to the <code>/v1/submissions</code> endpoint. We'll also need to supply some information to tell CMS how to identify this particular submission, which you can see below - every submission is unique to the combination of the fields provided.</p>
+          <p>We need to create a <em>submission</em> first. We can do that by asking the API to create a submission record in the CMS database. In API terms, this means making a <code>POST</code> (synonym for <em>create</em>) request to the <code>/submissions</code> endpoint. We'll also need to supply some information to tell CMS how to identify this particular submission, which you can see below - every submission is unique to the combination of the fields provided.</p>
           <p>Note that we enforce fake TINs (starting with <code>000</code>) during the preview period to avoid accidentally collecting personally identifiable information. Also, we can submit performance data in this first request as well, but we'll do it in a future request to keep this one small. On the right side, you can see the <code>JSON</code> version of the information below - click the 'Create Submission' button when you're ready.</p>
           <InlineApiExample
             verb="POST"
-            url="/v1/submissions"
+            url="/submissions"
             params={
               <tbody>
                 <tr><td>Program Name</td>
@@ -115,7 +115,7 @@ class BasicTutorial extends React.PureComponent {
           <p>If we want to add measurements from different categories (Advancing Care Information vs our Improvement Activity) or submission methods (not the CMS web interface), we would need to do that in another measurement set. Measurement sets become more important during scoring, since there can be performance data concerning the same care but submitted by different people - we'll dig into that in our advanced tutorial. For now, let's ask the API to add our IA measurement:</p>
           <InlineApiExample
             verb="POST"
-            url="/v1/measurement-sets"
+            url="/measurement-sets"
             params={
               <tbody>
                 <tr><td>Submission ID</td>
@@ -156,7 +156,7 @@ class BasicTutorial extends React.PureComponent {
           <p>With the submission <code>id</code> we were given, we can ask the API to calculate the submission score with a GET request. We don't need to include a request body this time since we're only interested in retrieving the score, and CMS doesn't need any information other than the submission <code>id</code>.</p>
           <InlineApiExample
             verb="GET"
-            url="/v1/submissions/:id/score"
+            url="/submissions/:id/score"
             button={
               <button
                 className="ds-c-button ds-c-button--primary"


### PR DESCRIPTION
We forgot to update these example url paths when we removed the versioning in the url. These are just static content to illustrate what api requests look like in the basic and advanced tutorials (they're not used in any programmatic fashion), but it's good to be correct.