### PR TITLE
Add qpp.cms.gov to header

### DIFF
--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -8,7 +8,7 @@ class Header extends React.PureComponent {
           <div className="container">
             <div className="navbar-header">
               <div className="header-mobile-brand">
-                <a className="header-brand" href="/">
+                <a className="header-brand" href="https://qpp.cms.gov/">
                   <img className="qpp-logo" src="https://qpp.cms.gov/images/qpp_logo_rgb_color.png" alt="qpp logo"></img>
                 </a>
               </div>


### PR DESCRIPTION
Locally, the "/" just redirects to the docs landing page, but when deployed it links to https://cmsgov.github.io which results in a 404.

Testing:
* [x] Test link locally