### PR TITLE
Ivanang make updates to dev docs sept 2017

### DIFF
--- a/src/components/api-reference/schemas/submissions.jsx
+++ b/src/components/api-reference/schemas/submissions.jsx
@@ -16,14 +16,14 @@ const FIELDS = [
   {name: 'measurementSets', value: 'array(measurementSet)', description: 'Measurement sets associated with the submission.',  notes: 'writable, optional'}
 ];
 
-export default class Submission extends React.Component {
+export default class Submissions extends React.Component {
   render() {
     // This is necessary to disable the default styles
     Tabs.setUseDefaultStyles(false);
     return (
        <div>
           <h1 className="ds-h1">Submissions</h1>
-          <p className="ds-text--lead">The Submissions resource represents one year of performance data for a given individual or group. Submissions contain MeasurementSets which can be accessed both via Submissions methods and MeasurementSets methods.</p>
+          <p className="ds-text--lead">The Submissions resource represents one year of performance data for a given individual or group. Submissions contain MeasurementSets which can be accessed both via Submissions methods and MeasurementSets methods. Submissions resources are 'shared' in the sense that they contain Measurement Sets that may be created by multiple users.</p>
           <p className="ds-text--lead"><a href="https://qpp-submissions-sandbox.navapbc.com/#/Submissions">Try it out!</a></p>
           <h2 className="ds-h2">Resource Representation</h2>
           <div>

--- a/src/components/api-reference/schemas/submissions.jsx
+++ b/src/components/api-reference/schemas/submissions.jsx
@@ -24,6 +24,7 @@ export default class Submissions extends React.Component {
        <div>
           <h1 className="ds-h1">Submissions</h1>
           <p className="ds-text--lead">The Submissions resource represents one year of performance data for a given individual or group. Submissions contain MeasurementSets which can be accessed both via Submissions methods and MeasurementSets methods. Submissions resources are 'shared' in the sense that they contain Measurement Sets that may be created by multiple users.</p>
+          <p className="ds-text--lead">Submissions resources are 'shared' in the sense that they contain Measurement Sets that may be created by multiple users.</p>          
           <p className="ds-text--lead"><a href="https://qpp-submissions-sandbox.navapbc.com/#/Submissions">Try it out!</a></p>
           <h2 className="ds-h2">Resource Representation</h2>
           <div>

--- a/src/components/app.test.js
+++ b/src/components/app.test.js
@@ -7,7 +7,7 @@ import Introduction from './introduction';
 import DeveloperPreview from './developer-preview';
 import BasicTutorial from './tutorials/basic-tutorial';
 import AdvancedTutorial from './tutorials/advanced-tutorial';
-import Submission from './api-reference/schemas/submission';
+import Submissions from './api-reference/schemas/submissions';
 import MeasurementSets from './api-reference/schemas/measurement-sets';
 import Measurements from './api-reference/schemas/measurements';
 import Benchmarks from './api-reference/schemas/benchmarks';
@@ -24,7 +24,7 @@ const expectedRoutes = {
   '/developer-preview': <DeveloperPreview />,
   '/tutorial': <BasicTutorial />,
   '/advanced-tutorial': <AdvancedTutorial />,
-  '/submission': <Submission />,
+  '/submissions': <Submissions />,
   '/measurement-sets': <MeasurementSets />,
   '/measurements': <Measurements />,
   '/benchmarks': <Benchmarks />,

--- a/src/components/developer-preview.js
+++ b/src/components/developer-preview.js
@@ -36,7 +36,7 @@ export default class DeveloperPreview extends React.Component {
           Check out the video below to help you get started:
         </p>
         <p className='ds-text'>
-          <iframe width="560" height="315" src="https://www.youtube.com/embed/702HKMoYqI0?rel=0" frameborder="0" allowfullscreen></iframe>
+          <iframe title='How to make your first call in the Developer Preview' width='560' height='315' src='https://www.youtube.com/embed/702HKMoYqI0?rel=0' frameBorder='0' allowFullScreen></iframe>
         </p>
         <p className='ds-text'>
           Today, Developers are using the Submission API to:

--- a/src/components/developer-preview.js
+++ b/src/components/developer-preview.js
@@ -37,7 +37,7 @@ export default class DeveloperPreview extends React.Component {
           Check out the video below to help you get started:
         </p>
         <p className='ds-text'>
-          <iframe title='How to make your first call in the Developer Preview' width='560' height='315' src='https://www.youtube.com/embed/702HKMoYqI0?rel=0' frameBorder='0' allowFullScreen>
+          <iframe title='How to make your first call in the Developer Preview' width='560' height='315' src='https://www.youtube.com/embed/702HKMoYqI0?rel=0' frameBorder='0' allowFullScreen></iframe>
         </p>
         <p className='ds-text'>
           Today, Developers are using the Submission API to:

--- a/src/components/developer-preview.js
+++ b/src/components/developer-preview.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import 'uswds/dist/js/uswds.js';
-import Iframe from 'react-iframe';
-
 import '@cmsgov/design-system-core/dist/index.css';
 import '../styles/app.css';
 import '../styles/temp-grid.css';

--- a/src/components/developer-preview.js
+++ b/src/components/developer-preview.js
@@ -32,7 +32,12 @@ export default class DeveloperPreview extends React.Component {
         <h2 className='ds-h2'>Step 3: Make your first API call</h2>
         <p className='ds-text'>Base URL: <b><code>https://qpp.cms.gov/api/submissions</code></b></p>
         <p className='ds-text'>Add your API Token to the header of every API request using the key value: <code>Authorization: Bearer [YOUR API TOKEN]</code>. </p>
-
+        <p className='ds-text'>
+          Check out the video below to help you get started:
+        </p>
+        <p className='ds-text'>
+          <iframe width="560" height="315" src="https://www.youtube.com/embed/702HKMoYqI0?rel=0&amp;controls=0&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
+        </p>
         <p className='ds-text'>
           Today, Developers are using the Submission API to:
         </p>

--- a/src/components/developer-preview.js
+++ b/src/components/developer-preview.js
@@ -35,7 +35,7 @@ export default class DeveloperPreview extends React.Component {
           Check out the video below to help you get started:
         </p>
         <p className='ds-text'>
-          <iframe title='How to make your first call in the Developer Preview' width='560' height='315' src='https://www.youtube.com/embed/702HKMoYqI0?rel=0' frameBorder='0' allowFullScreen></iframe>
+          <iframe title='How to make your first call in the Developer Preview' width='560' height='315' src='https://www.youtube.com/embed/702HKMoYqI0?rel=0' frameBorder='0' allowFullScreen />
         </p>
         <p className='ds-text'>
           Today, Developers are using the Submission API to:

--- a/src/components/developer-preview.js
+++ b/src/components/developer-preview.js
@@ -34,9 +34,9 @@ export default class DeveloperPreview extends React.Component {
         <p className='ds-text'>
           Check out the video below to help you get started:
         </p>
-        <div style='text-align:center;'> 
+        <p style='text-align:center'> 
           <iframe title='How to make your first call in the Developer Preview' width='560' height='315' src='https://www.youtube.com/embed/702HKMoYqI0?rel=0' frameBorder='0' allowFullScreen />
-        </div>
+        </p>
         <p className='ds-text'>
           Today, Developers are using the Submission API to:
         </p>

--- a/src/components/developer-preview.js
+++ b/src/components/developer-preview.js
@@ -23,7 +23,7 @@ export default class DeveloperPreview extends React.Component {
         <p className='ds-text'>Please note: API Tokens expire at the end of the Developer Preview period, at which time new API Tokens will become available through an automated, self-service process.</p>
 
         <h2 className='ds-h2'>Step 2: Explore the API</h2>
-        <p className='ds-text'>View the <a href='https://cmsgov.github.io/qpp-submissions-docs/schemas'>API documentation</a> or play around with the <a href='https://qpp-submissions-sandbox.navapbc.com/'>Interactive Docs</a> using your own data.</p>
+        <p className='ds-text'>For a comprehensive list of endpoints and documentation on how to format your requests, play around with the <a href='https://qpp-submissions-sandbox.navapbc.com/'>Interactive Docs</a> using your own data.</p>
         <SubmissionsObjects />
 
         <p className='ds-text'>Walk through how to create a new submission, submit measures and receive real-time scoring in the below tutorial.</p>

--- a/src/components/developer-preview.js
+++ b/src/components/developer-preview.js
@@ -34,7 +34,7 @@ export default class DeveloperPreview extends React.Component {
         <p className='ds-text'>
           Check out the video below to help you get started:
         </p>
-          <iframe title='How to make your first call in the Developer Preview' width='560' height='315' align='center' src='https://www.youtube.com/embed/702HKMoYqI0?rel=0' frameBorder='0' allowFullScreen />
+          <iframe title='How to make your first call in the Developer Preview' width='560' height='315' align='middle' src='https://www.youtube.com/embed/702HKMoYqI0?rel=0' frameBorder='0' allowFullScreen />
         <p className='ds-text'>
           Today, Developers are using the Submission API to:
         </p>

--- a/src/components/developer-preview.js
+++ b/src/components/developer-preview.js
@@ -34,7 +34,9 @@ export default class DeveloperPreview extends React.Component {
         <p className='ds-text'>
           Check out the video below to help you get started:
         </p>
-          <iframe title='How to make your first call in the Developer Preview' width='560' height='315' align='middle' src='https://www.youtube.com/embed/702HKMoYqI0?rel=0' frameBorder='0' allowFullScreen />
+        <div style='text-align:center;'> 
+          <iframe title='How to make your first call in the Developer Preview' width='560' height='315' src='https://www.youtube.com/embed/702HKMoYqI0?rel=0' frameBorder='0' allowFullScreen />
+        </div>
         <p className='ds-text'>
           Today, Developers are using the Submission API to:
         </p>

--- a/src/components/developer-preview.js
+++ b/src/components/developer-preview.js
@@ -36,7 +36,7 @@ export default class DeveloperPreview extends React.Component {
           Check out the video below to help you get started:
         </p>
         <p className='ds-text'>
-          <iframe title='How to make your first call in the Developer Preview' width='560' height='315' src='https://www.youtube.com/embed/702HKMoYqI0?rel=0' frameBorder='0' allowFullScreen>
+          <iframe title='How to make your first call in the Developer Preview' width='560' height='315' src='https://www.youtube.com/embed/702HKMoYqI0?rel=0' frameBorder='0' allowFullScreen></iframe>
         </p>
         <p className='ds-text'>
           Today, Developers are using the Submission API to:

--- a/src/components/developer-preview.js
+++ b/src/components/developer-preview.js
@@ -36,7 +36,7 @@ export default class DeveloperPreview extends React.Component {
           Check out the video below to help you get started:
         </p>
         <p className='ds-text'>
-          <iframe width="560" height="315" src="https://www.youtube.com/embed/702HKMoYqI0?rel=0&amp;controls=0&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
+          <iframe width="560" height="315" src="https://www.youtube.com/embed/702HKMoYqI0?rel=0" frameborder="0" allowfullscreen></iframe>
         </p>
         <p className='ds-text'>
           Today, Developers are using the Submission API to:

--- a/src/components/developer-preview.js
+++ b/src/components/developer-preview.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import 'uswds/dist/js/uswds.js';
+import Iframe from 'react-iframe';
 
 import '@cmsgov/design-system-core/dist/index.css';
 import '../styles/app.css';
@@ -36,7 +37,7 @@ export default class DeveloperPreview extends React.Component {
           Check out the video below to help you get started:
         </p>
         <p className='ds-text'>
-          <iframe title='How to make your first call in the Developer Preview' width='560' height='315' src='https://www.youtube.com/embed/702HKMoYqI0?rel=0' frameBorder='0' allowFullScreen></iframe>
+          <iframe title='How to make your first call in the Developer Preview' width='560' height='315' src='https://www.youtube.com/embed/702HKMoYqI0?rel=0' frameBorder='0' allowFullScreen>
         </p>
         <p className='ds-text'>
           Today, Developers are using the Submission API to:

--- a/src/components/developer-preview.js
+++ b/src/components/developer-preview.js
@@ -34,9 +34,7 @@ export default class DeveloperPreview extends React.Component {
         <p className='ds-text'>
           Check out the video below to help you get started:
         </p>
-        <p className='ds-text'>
-          <iframe title='How to make your first call in the Developer Preview' width='560' height='315' src='https://www.youtube.com/embed/702HKMoYqI0?rel=0' frameBorder='0' allowFullScreen />
-        </p>
+          <iframe title='How to make your first call in the Developer Preview' width='560' height='315' align='center' src='https://www.youtube.com/embed/702HKMoYqI0?rel=0' frameBorder='0' allowFullScreen />
         <p className='ds-text'>
           Today, Developers are using the Submission API to:
         </p>

--- a/src/components/developer-preview.js
+++ b/src/components/developer-preview.js
@@ -36,7 +36,7 @@ export default class DeveloperPreview extends React.Component {
           Check out the video below to help you get started:
         </p>
         <p className='ds-text'>
-          <iframe title='How to make your first call in the Developer Preview' width='560' height='315' src='https://www.youtube.com/embed/702HKMoYqI0?rel=0' frameBorder='0' allowFullScreen></iframe>
+          <iframe title='How to make your first call in the Developer Preview' width='560' height='315' src='https://www.youtube.com/embed/702HKMoYqI0?rel=0' frameBorder='0' allowFullScreen>
         </p>
         <p className='ds-text'>
           Today, Developers are using the Submission API to:

--- a/src/components/developer-preview.js
+++ b/src/components/developer-preview.js
@@ -34,9 +34,7 @@ export default class DeveloperPreview extends React.Component {
         <p className='ds-text'>
           Check out the video below to help you get started:
         </p>
-        <p style='text-align:center'> 
           <iframe title='How to make your first call in the Developer Preview' width='560' height='315' src='https://www.youtube.com/embed/702HKMoYqI0?rel=0' frameBorder='0' allowFullScreen />
-        </p>
         <p className='ds-text'>
           Today, Developers are using the Submission API to:
         </p>

--- a/src/components/developer-preview.js
+++ b/src/components/developer-preview.js
@@ -34,7 +34,7 @@ export default class DeveloperPreview extends React.Component {
         <p className='ds-text'>
           Check out the video below to help you get started:
         </p>
-          <iframe title='How to make your first call in the Developer Preview' width='560' height='315' src='https://www.youtube.com/embed/702HKMoYqI0?rel=0' frameBorder='0' allowFullScreen />
+        <iframe title='How to make your first call in the Developer Preview' width='560' height='315' src='https://www.youtube.com/embed/702HKMoYqI0?rel=0' frameBorder='0' allowFullScreen />
         <p className='ds-text'>
           Today, Developers are using the Submission API to:
         </p>

--- a/src/components/introduction.js
+++ b/src/components/introduction.js
@@ -13,7 +13,6 @@ class Introduction extends React.Component {
         <Link to='/developer-preview' className='ds-c-button ds-c-button--primary'>Join the QPP Developer Preview</Link>
 
         <h2 className='ds-h2'>Explore the API</h2>
-        <p className='ds-text'>View the <Link to='/schemas'>API documentation</Link> or play around with the <a href='https://qpp-submissions-sandbox.navapbc.com/'>Interactive Docs</a> using your own data.</p>
         <SubmissionsObjects />
 
         <p className='ds-text'>Walk through how to create a new submission, submit measures and receive real-time scoring in the below tutorial.</p>

--- a/src/components/routes.jsx
+++ b/src/components/routes.jsx
@@ -48,23 +48,23 @@ const guidesPaths = [
 
 const referencePaths = [
   {
-    path: '/submission',
+    path: '/measurements',
     exact: false,
-    linkText: 'Submission',
-    component: Submission
+    linkText: 'Measurements',
+    component: Measurements
   },
   {
     path: '/measurement-sets',
     exact: false,
     linkText: 'Measurement Sets',
     component: MeasurementSets
-  },
+  },  
   {
-    path: '/measurements',
+    path: '/submission',
     exact: false,
-    linkText: 'Measurements',
-    component: Measurements
-  },
+    linkText: 'Submission',
+    component: Submission
+  },  
   {
     path: '/benchmarks',
     exact: false,

--- a/src/components/routes.jsx
+++ b/src/components/routes.jsx
@@ -2,7 +2,7 @@ import DeveloperPreview from './developer-preview';
 import Introduction from './introduction';
 import BasicTutorial from './tutorials/basic-tutorial';
 import AdvancedTutorial from './tutorials/advanced-tutorial';
-import Submission from './api-reference/schemas/submission';
+import Submissions from './api-reference/schemas/submissions';
 import MeasurementSets from './api-reference/schemas/measurement-sets';
 import Measurements from './api-reference/schemas/measurements';
 import Benchmarks from './api-reference/schemas/benchmarks';
@@ -60,10 +60,10 @@ const referencePaths = [
     component: MeasurementSets
   },  
   {
-    path: '/submission',
+    path: '/submissions',
     exact: false,
-    linkText: 'Submission',
-    component: Submission
+    linkText: 'Submissions',
+    component: Submissions
   },  
   {
     path: '/benchmarks',

--- a/src/components/routes.jsx
+++ b/src/components/routes.jsx
@@ -22,6 +22,12 @@ const topicsPaths = [
     exact: false,
     linkText: 'Developer Preview',
     component: DeveloperPreview
+  },
+  {
+    path: 'https://qpp-submissions-sandbox.navapbc.com',
+    exact: false,
+    linkText: 'Interactive Documentation',
+    external: true
   }
 ];
 

--- a/src/components/routes.jsx
+++ b/src/components/routes.jsx
@@ -20,7 +20,7 @@ const topicsPaths = [
   {
     path: '/developer-preview',
     exact: false,
-    linkText: 'Getting a Key',
+    linkText: 'Developer Preview',
     component: DeveloperPreview
   }
 ];


### PR DESCRIPTION
Small fixes to Dev Docs content:

1. QPPA-1097 - change the text 'getting a key' to 'developer preview'
2. QPPA-1098 - add link to swagger under 'topics'
3. QPPA-1099 - embed youtube video in 'developer preview'
4. QPPA-1101 - change order of objects under 'references' to de-emphasize the submission object
5. QPPA-1072 - add sentence to 'submissions' page to make clear that the object is 'shared' - also change to 'submissions' (plural) to be consistent with the other pages