### PR TITLE
remove obsolete narrow screen warning

### DIFF
--- a/src/components/tutorials/advanced-tutorial.js
+++ b/src/components/tutorials/advanced-tutorial.js
@@ -14,12 +14,6 @@ class AdvancedTutorial extends React.Component {
 
     return (
       <div>
-        <div className='ds-c-alert ds-c-alert--info narrow-screen-warning'>
-          <div className='ds-c-alert--body'>
-            <h3 className='ds-c-alert--heading'>Example code on mobile</h3>
-            <p className='ds-c-alert--text'>Looks like the screen is too narrow to show you the API payloads alongside the tutorial. As you see references to code on the right, you'll be able to find it all the way at the bottom. Clicking the buttons to progress through the tutorial will update the code!</p>
-          </div>
-        </div>
         <div>
           <div className='temp-grid'>
             <h1 className='ds-h1'>Advanced API Tutorial</h1>


### PR DESCRIPTION
Forgot to remove the narrow screen warning for the advanced tutorial - doing so here
<img width="672" alt="screen shot 2017-09-13 at 9 57 15 am" src="https://user-images.githubusercontent.com/279406/30390166-fe7aef06-9869-11e7-89b2-9aacae88f989.png">