### PR TITLE
remove unused example code tabs

### DIFF
--- a/src/components/tutorials/common/steps/advanced-3.js
+++ b/src/components/tutorials/common/steps/advanced-3.js
@@ -10,10 +10,8 @@ class Advanced3 extends React.PureComponent {
     return (
       <Tabs className={cssClass}>
         <TabList>
-          <Tab>Request</Tab>
           <Tab>Response</Tab>
         </TabList>
-        <TabPanel />
         <TabPanel>
           <p>Response code:</p>
           <pre>200 OK</pre>

--- a/src/components/tutorials/common/steps/advanced-5.js
+++ b/src/components/tutorials/common/steps/advanced-5.js
@@ -10,10 +10,8 @@ class Advanced5 extends React.PureComponent {
     return (
       <Tabs className={cssClass}>
         <TabList>
-          <Tab>Request</Tab>
           <Tab>Response</Tab>
         </TabList>
-        <TabPanel />
         <TabPanel>
           <p>Response code:</p>
           <pre>200 OK</pre>

--- a/src/components/tutorials/common/steps/basic-3.js
+++ b/src/components/tutorials/common/steps/basic-3.js
@@ -10,10 +10,8 @@ class Basic3 extends React.PureComponent {
     return (
       <Tabs className={cssClass}>
         <TabList>
-          <Tab>Request</Tab>
           <Tab>Response</Tab>
         </TabList>
-        <TabPanel />
         <TabPanel>
           <p>Response code:</p>
           <pre>200 OK</pre>


### PR DESCRIPTION
We have a couple example code tabs that are blank, which is possibly confusing for folks using the tutorial - we kept them blank previously since there was logic associated with having the two tabs. Since that logic has been removed, we can get rid of the blank tabs that look like this:
<img width="522" alt="screen shot 2017-09-13 at 10 11 08 am" src="https://user-images.githubusercontent.com/279406/30390762-04f51c88-986c-11e7-931f-a5a2e8216706.png">

the 'after' for the three blank tabs:
<img width="558" alt="screen shot 2017-09-13 at 10 08 53 am" src="https://user-images.githubusercontent.com/279406/30390770-0dd0b524-986c-11e7-991f-d1116c0e158c.png">
<img width="419" alt="screen shot 2017-09-13 at 10 07 59 am" src="https://user-images.githubusercontent.com/279406/30390772-0dd7dc82-986c-11e7-8e01-a0a16f5a795a.png">
<img width="484" alt="screen shot 2017-09-13 at 10 06 34 am" src="https://user-images.githubusercontent.com/279406/30390771-0dd23502-986c-11e7-9851-ee0a4f24d99f.png">
