### PR TITLE
[QPPA-1065] Add react-compatible google analytics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,19 +14,6 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>QPP Submissions API Developer Documentation</title>
-    <!--START Google Analytics tracking code - to set up cross-domain tracking from qpp.cms.gov to cmsgov.github.io-->
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-      
-      ga('create', 'UA-15356370-63', 'auto', {'allowLinker': true});
-      ga('require', 'linker');
-      ga('linker:autoLink', ['qpp.cms.gov'] );
-      ga('send', 'pageview');
-   </script>
-   <!--END Google Analytics tracking code - to set up cross-domain tracking from qpp.cms.gov to cmsgov.github.io-->    
   </head>
   <body class="ds-base">
     <div id="root"></div>

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,35 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { BrowserRouter } from 'react-router-dom';
+import { Router } from 'react-router-dom';
+import { createBrowserHistory } from 'history';
 import App from './components/app';
 
+const basePath = '/qpp-submissions-docs';
+const history = createBrowserHistory({
+	basename: basePath
+});
+
+const initGA = (history) => {
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  // allow cross-domain tracking from qpp.cms.gov to cmsgov.github.io
+	window.ga('create', 'UA-15356370-63', 'auto', {'allowLinker': true});
+	window.ga('require', 'linker');
+	window.ga('linker:autoLink', ['qpp.cms.gov'] );
+
+  history.listen((location) => {
+    window.ga('send', 'pageview', basePath + location.pathname);
+  });
+};
+
+initGA(history);
+
 ReactDOM.render(
-  <BrowserRouter basename='/qpp-submissions-docs'>
+  <Router history={history}>
     <App />
-  </BrowserRouter>,
+  </Router>,
   document.getElementById('root')
 );

--- a/src/index.js
+++ b/src/index.js
@@ -6,9 +6,10 @@ import App from './components/app';
 
 const basePath = '/qpp-submissions-docs';
 const history = createBrowserHistory({
-	basename: basePath
+  basename: basePath
 });
 
+/* eslint-disable */
 const initGA = (history) => {
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -16,14 +17,15 @@ const initGA = (history) => {
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
   // allow cross-domain tracking from qpp.cms.gov to cmsgov.github.io
-	window.ga('create', 'UA-15356370-63', 'auto', {'allowLinker': true});
-	window.ga('require', 'linker');
-	window.ga('linker:autoLink', ['qpp.cms.gov'] );
+  window.ga('create', 'UA-15356370-63', 'auto', {'allowLinker': true});
+  window.ga('require', 'linker');
+  window.ga('linker:autoLink', ['qpp.cms.gov'] );
 
   history.listen((location) => {
     window.ga('send', 'pageview', basePath + location.pathname);
   });
 };
+/*eslint-enable */
 
 initGA(history);
 


### PR DESCRIPTION
This PR makes our Google Analytics code work when navigating between different pages. Currently only the initial pageview URL is being sent to GA, this PR sends every subsequent URL as well.

Testing: I set up a test GA account and verified that this PR works when sending data there, so it should work with our production account as well. Passes all unit tests.

JIRA: https://jira.cms.gov/browse/QPPA-1065

After landing on the home page, navigating to /measurements updates GA correctly:
![image](https://user-images.githubusercontent.com/82277/30834471-16b5f9a6-a208-11e7-8922-74b3c319724a.png)

Navigating to /measurement-sets also updates GA correctly:
![image](https://user-images.githubusercontent.com/82277/30834511-3e01c224-a208-11e7-8baa-1452ae0733f8.png)

Reviewer: @kencheeto 

