### PR TITLE
add tins to special scoring section of dev preview

### DIFF
--- a/src/components/developer-preview.js
+++ b/src/components/developer-preview.js
@@ -232,7 +232,6 @@ class DeveloperPreview extends React.Component {
               <td>000000022</td>
               <td>Participates in an Oncology Care Model APM</td>
             </tr>
-            </tr>
             <tr>
               <td>000000023</td>
               <td>Participates in a Shared Savings Plan (SSP) APM, has only primary provider relationships to the SSP APM, and participates in an Improvement Activity Study</td>

--- a/src/components/developer-preview.js
+++ b/src/components/developer-preview.js
@@ -232,6 +232,15 @@ class DeveloperPreview extends React.Component {
               <td>000000022</td>
               <td>Participates in an Oncology Care Model APM</td>
             </tr>
+            </tr>
+            <tr>
+              <td>000000023</td>
+              <td>Participates in a Shared Savings Plan (SSP) APM, has only primary provider relationships to the SSP APM, and participates in an Improvement Activity Study</td>
+            </tr> 
+            <tr>
+              <td>000000024</td>
+              <td>Participates in a standard MIPS APM, and participates in an Improvement Activity Study</td>
+            </tr>     
           </tbody>
         </table>
 

--- a/src/components/developer-preview.js
+++ b/src/components/developer-preview.js
@@ -235,11 +235,11 @@ class DeveloperPreview extends React.Component {
             <tr>
               <td>000000023</td>
               <td>Participates in a Shared Savings Plan (SSP) APM, has only primary provider relationships to the SSP APM, and participates in an Improvement Activity Study</td>
-            </tr> 
+            </tr>
             <tr>
               <td>000000024</td>
               <td>Participates in a standard MIPS APM, and participates in an Improvement Activity Study</td>
-            </tr>     
+            </tr>
           </tbody>
         </table>
 


### PR DESCRIPTION
Two additional TINs were added to https://confluence.cms.gov/display/QPPARCH/TIN+to+Provider+Relationships. I am updating this page to reflect that.