### PR TITLE
Remove old text from dev docs

### DIFF
--- a/src/components/tutorials/qualified-registries-and-qcdrs.js
+++ b/src/components/tutorials/qualified-registries-and-qcdrs.js
@@ -8,7 +8,7 @@ class SubmittingToSubmissionsApi extends React.Component {
         <p className='ds-text'>Tokens are specific to your organization and are specific to the environment within the Submissions API. Developer Preview tokens are for testing against the Submissions API in the Developer Preview environment. Production token are for submitting during the specific performance year's submissions window to the production environment of the Submissions API.</p>
         <p className='ds-text'>If you are a Registry or QCDR using the Developer Preview, you have an API key that is associated with an 'organization'. This affects what endpoints you are authorized to use, and what behavior each endpoint has. </p>
         <p className='ds-text'>At a high level, your API key allows you to create and edit data using the <code>/measurement-sets</code> and <code>/measurements</code> endpoints. You cannot create data using the <code>/submissions</code> endpoint. For more information about what you're authorized to do with the Submissions API, click <a href='/qpp-submissions-docs/developer-preview#authorization'>here</a>.</p>
-        
+
         <h1 className='ds-h1' id='authentication'>Authentication</h1>
         <p className='ds-text'>You must authenticate your account when using the Submissions API. Authenticate via bearer auth by adding your API token to the header of every request using the key value: <strong>Authorization: Bearer [YOUR API TOKEN]</strong>.</p>
         <p className='ds-text'>API keys carry many privileges, and must not be shared in publicly accessible areas such as GitHub and in client-side code.  Even within organizations, access must be limited to staff embedding it in software.</p>

--- a/src/components/tutorials/qualified-registries-and-qcdrs.js
+++ b/src/components/tutorials/qualified-registries-and-qcdrs.js
@@ -8,14 +8,7 @@ class SubmittingToSubmissionsApi extends React.Component {
         <p className='ds-text'>Tokens are specific to your organization and are specific to the environment within the Submissions API. Developer Preview tokens are for testing against the Submissions API in the Developer Preview environment. Production token are for submitting during the specific performance year's submissions window to the production environment of the Submissions API.</p>
         <p className='ds-text'>If you are a Registry or QCDR using the Developer Preview, you have an API key that is associated with an 'organization'. This affects what endpoints you are authorized to use, and what behavior each endpoint has. </p>
         <p className='ds-text'>At a high level, your API key allows you to create and edit data using the <code>/measurement-sets</code> and <code>/measurements</code> endpoints. You cannot create data using the <code>/submissions</code> endpoint. For more information about what you're authorized to do with the Submissions API, click <a href='/qpp-submissions-docs/developer-preview#authorization'>here</a>.</p>
-        <h2 className='ds-h2'>Authentication</h2>
-        <p className='ds-text'>Both the Developer Preview and the Production environments require a JSON Web Token ("API key") for authentication purposes.</p>
-
-        <h1 className='ds-h1' id='api-key'>Get an API Key</h1>
-        <a className='ds-c-button ds-c-button--primary' href='/qpp-submissions-docs/developer-preview#api-key'>Get an API Key</a>
-        <p className='ds-text'>The Developer Preview is open year round and currently supports PY 2018 testing. As such, the Developer Preview is open to 2018 CMS-approved Qualified Registries ("registries") and Qualified Clinical Data Registries ("QCDRs").</p>
-        <p className='ds-text'>Developer Preview tokens for 2019 registries and QCDRs will become available when the testing environment switches from supporting PY 2018 to PY 2019 later this year.</p>
-        <p className='ds-text'>Anyone may continue to test the current iteration of the Developer Preview environment through our <a href='https://preview.qpp.cms.gov/api/submissions/public/docs/'>Interactive Documentation</a>. A default API token is embedded on this website, which you may also use for testing. To retrieve this token, test any endpoint on the website and then copy it from the API's cURL response.</p>
+        
         <h1 className='ds-h1' id='authentication'>Authentication</h1>
         <p className='ds-text'>You must authenticate your account when using the Submissions API. Authenticate via bearer auth by adding your API token to the header of every request using the key value: <strong>Authorization: Bearer [YOUR API TOKEN]</strong>.</p>
         <p className='ds-text'>API keys carry many privileges, and must not be shared in publicly accessible areas such as GitHub and in client-side code.  Even within organizations, access must be limited to staff embedding it in software.</p>


### PR DESCRIPTION
Missed a section that should be removed in our latest update for the new dev docs, see confluence page to confirm and review what's there vs what's on the dev docs as is please