### PR TITLE
QPPA-4756: added snyk file to ignore react-scripts v4 upgrade

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,7 +4,7 @@ ignore:
   SNYK-JS-NODENOTIFIER-1035794:
     - '* > node-notifier':
         reason: 'v4.0.0 of react-scripts is code breaking'
-        expires: '2021-03-19T12:00:00.000Z'
+        expires: '2021-04-01T00:00:00.000Z'
     - '* > react-scripts':
         reason: 'v4.0.0 of react-scripts is code breaking'
-        expires: '2021-03-19T12:00:00.000Z'
+        expires: '2021-04-01T00:00:00.000Z'

--- a/.snyk
+++ b/.snyk
@@ -2,9 +2,6 @@
 version: v1.14.1
 ignore:
   SNYK-JS-NODENOTIFIER-1035794:
-    - '* > node-notifier':
-        reason: 'v4.0.0 of react-scripts is code breaking'
-        expires: '2021-04-01T00:00:00.000Z'
     - '* > react-scripts':
         reason: 'v4.0.0 of react-scripts is code breaking'
         expires: '2021-04-01T00:00:00.000Z'

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,10 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.14.1
+ignore:
+  SNYK-JS-NODENOTIFIER-1035794:
+    - '* > node-notifier':
+        reason: 'v4.0.0 of react-scripts is code breaking'
+        expires: '2021-03-19T12:00:00.000Z'
+    - '* > react-scripts':
+        reason: 'v4.0.0 of react-scripts is code breaking'
+        expires: '2021-03-19T12:00:00.000Z'

--- a/package-lock.json
+++ b/package-lock.json
@@ -3753,6 +3753,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -7125,6 +7134,12 @@
         "schema-utils": "^2.5.0"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filename-reserved-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
@@ -9156,6 +9171,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         }
@@ -17018,6 +17034,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },


### PR DESCRIPTION


## Description
snyk is currently flagging react-scripts 3.4.4 as a vulnerability and is trying to upgrade it to v4.0.0, which breaks the application. This PR as a .snyk file that ignores the effected folders.

## How Has This Been Tested?
unit tests passing, tested locally.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
