### PR TITLE
Removing bad and duplicate text

### DIFF
--- a/src/app/components/guides/submitting-to-submissions-api.tsx
+++ b/src/app/components/guides/submitting-to-submissions-api.tsx
@@ -11,7 +11,7 @@ const SubmittingToQppSubmissionApi = () => {
         The Submissions API is a RESTful API. It has predictable, resource-oriented URLs, and uses HTTP response codes to indicate API errors. It uses standard HTTP features, like HTTPS authentication and HTTP verbs, which are understood by off-the-shelf HTTP clients.
       </p>
       <p className='ds-text'>
-        The Submissions API supports cross-origin resource sharing, allowing you to interact securely with the API from a client-side web application (though you should never expose your secret API key in any public websites client-side code).
+        The Submissions API supports cross-origin resource sharing, allowing you to interact securely with the API from a client-side web application (though you should never expose your secret API key in any public website's client-side code).
       </p>
       <p className='ds-text'>API responses are returned in JSON, including errors.</p>
 

--- a/src/app/components/guides/submitting-to-submissions-api.tsx
+++ b/src/app/components/guides/submitting-to-submissions-api.tsx
@@ -11,7 +11,7 @@ const SubmittingToQppSubmissionApi = () => {
         The Submissions API is a RESTful API. It has predictable, resource-oriented URLs, and uses HTTP response codes to indicate API errors. It uses standard HTTP features, like HTTPS authentication and HTTP verbs, which are understood by off-the-shelf HTTP clients.
       </p>
       <p className='ds-text'>
-        The Submissions API supports cross-origin resource sharing, allowing you to interact securely with the API from a client-side web application (though you should never expose your secret API key in any public websiteâ€™s client-side code).
+        The Submissions API supports cross-origin resource sharing, allowing you to interact securely with the API from a client-side web application (though you should never expose your secret API key in any public websites client-side code).
       </p>
       <p className='ds-text'>API responses are returned in JSON, including errors.</p>
 
@@ -36,4 +36,3 @@ const SubmittingToQppSubmissionApi = () => {
 };
 
 export default SubmittingToQppSubmissionApi;
-

--- a/src/app/components/references/submissions.tsx
+++ b/src/app/components/references/submissions.tsx
@@ -8,7 +8,7 @@ const Submissions = () => {
     <>
       <h2 className='ds-h2'>Submissions</h2>
       <p className='ds-text--lead'>
-        The Submissions resource represents one year of performance data for a given individual or group. Submissions contain MeasurementSets which can be accessed both via Submissions methods and MeasurementSets methods. Submissions resources are 'shared' in the sense that they contain Measurement Sets that may be created by multiple users.
+        The Submissions resource represents one year of performance data for a given individual or group. Submissions contain MeasurementSets which can be accessed both via Submissions methods and MeasurementSets methods.
       </p>
       <p className='ds-text--lead'>
         Submissions resources are 'shared' in the sense that they contain Measurement Sets that may be created by multiple users.


### PR DESCRIPTION
Removes bad characters on the Submission reference page and duplicate text on the submitting guide.

Tests and Linter passing locally.