### PR TITLE
Added link to Scoring API docs

### DIFF
--- a/src/app/components/references/references.tsx
+++ b/src/app/components/references/references.tsx
@@ -6,7 +6,7 @@ import envConfig from '../../../envConfig';
 const References = () => {
   return (
     <>
-      <p className='qpp-docs-page-updated'>Last Updated: 08/26/2020</p> {/* IMPORTANT: update this Last-Updated value if you have made any changes to this page's content. */}
+      <p className='qpp-docs-page-updated'>Last Updated: 05/12/2021</p> {/* IMPORTANT: update this Last-Updated value if you have made any changes to this page's content. */}
       <h2 className='ds-h2' style={{marginTop: 0}} id='references'>References</h2>
 
       <h3 className='ds-h3'>General References</h3>
@@ -23,6 +23,9 @@ const References = () => {
       <ul>
         <li>
           Interactive QPP Submissions API Documentation: <ExternalLink href={`${envConfig.qppCmsPreviewUrl}/api/submissions/public/docs`} />
+        </li>
+        <li>
+          Interactive QPP Scoring API Documentation: <ExternalLink href={`${envConfig.qppCmsUrl}/api/scoring/docs`} />
         </li>
         <li>
           Measures, Activities, and Benchmarks Repository: <ExternalLink href={`https://github.com/CMSgov/qpp-measures-data`} />


### PR DESCRIPTION
## Description
Added link to Scoring API documentation under the references page.

## Motivation and Context
The Scoring API was mentioned but no links to the swagger docs were provided.

## How Has This Been Tested?
Ran app locally and verified link and updated timestamp.

## Screenshots (if appropriate):

<img width="783" alt="Screen Shot 2021-05-12 at 11 01 04 AM" src="https://user-images.githubusercontent.com/75799168/117997963-7396a300-b311-11eb-8eaa-b884d482bf9c.png">

## Types of Changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:
- [x] I have updated the Last-Updated value on all documentation pages where I changed content.
- [x] My code follows the code style of this project.