### PR TITLE
QPPA-5609: Upgrade to New Version of CMS Design NPM Package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1224,39 +1224,22 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
-    "@cmsgov/design-system-core": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@cmsgov/design-system-core/-/design-system-core-3.7.2.tgz",
-      "integrity": "sha512-IyC/EPU5clQ8wxNLM42ZrUyPLuhuttt8iVv/wg4VRWIb9EgFz2cvVsIRUEsgtz20u5YaxcrXBHIGHpwhvAvZAw==",
+    "@cmsgov/design-system": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@cmsgov/design-system/-/design-system-2.8.0.tgz",
+      "integrity": "sha512-VbICJr9vG/0E29dGw4R+9XyQqDS4+t/8IF3VRZUdtAZ3LCGh3qlvLzYXRxUGuBt4kgon1MfN551gnYo4UJP6Gg==",
       "requires": {
-        "@cmsgov/design-system-support": "^3.7.0",
+        "@popperjs/core": "^2.4.4",
         "classnames": "^2.2.5",
-        "core-js": "^2.5.3",
+        "core-js": "^3.6.5",
         "downshift": "^3.2.10",
         "ev-emitter": "^1.1.1",
+        "focus-trap-react": "^6.0.0",
         "lodash.uniqueid": "^4.0.1",
-        "react-aria-modal": "^2.11.1"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.12",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-        }
+        "prop-types": "^15.7.2",
+        "react-aria-modal": "^2.11.1",
+        "react-transition-group": "^2.9.0"
       }
-    },
-    "@cmsgov/design-system-layout": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@cmsgov/design-system-layout/-/design-system-layout-3.7.2.tgz",
-      "integrity": "sha512-wAfLRIGKiFba7hNOAcx3Tl1AjYRmV2S/1jnVPg04TVax0OqDX8h+4b5IKM9h2GglG4DCU7URLjpmQqFF1Akk1w==",
-      "requires": {
-        "@cmsgov/design-system-support": "^3.7.2"
-      }
-    },
-    "@cmsgov/design-system-support": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@cmsgov/design-system-support/-/design-system-support-3.7.2.tgz",
-      "integrity": "sha512-zH9ArWkuOjiWNwmPsJgYFr05EdklPU1hTbGRPctJBldl0TUDKc5VVLAyWW+P5BNd4XEfH7tQhPjs3ZJroq1gvw=="
     },
     "@cnakazawa/watch": {
       "version": "1.0.4",
@@ -1888,6 +1871,11 @@
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
         }
       }
+    },
+    "@popperjs/core": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.2.tgz",
+      "integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ=="
     },
     "@rollup/plugin-node-resolve": {
       "version": "7.1.3",
@@ -4548,9 +4536,9 @@
       }
     },
     "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "clean-css": {
       "version": "4.2.3",
@@ -4801,9 +4789,9 @@
       }
     },
     "compute-scroll-into-view": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.16.tgz",
-      "integrity": "sha512-a85LHKY81oQnikatZYA90pufpZ6sQx++BoCxOEMsjpZx+ZnaKGQnCyCehTRr/1p9GBIAHTjcU9k71kSYWloLiQ=="
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
+      "integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -5694,6 +5682,14 @@
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "requires": {
         "utila": "~0.4"
+      }
+    },
+    "dom-helpers": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
       }
     },
     "dom-serializer": {
@@ -7623,19 +7619,20 @@
       }
     },
     "focus-trap": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-2.4.6.tgz",
-      "integrity": "sha512-vWZTPtBU6pBoyWZDRZJHkXsyP2ZCZBHE3DRVXnSVdQKH/mcDtu9S5Kz8CUDyIqpfZfLEyI9rjKJLnc4Y40BRBg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-4.0.2.tgz",
+      "integrity": "sha512-HtLjfAK7Hp2qbBtLS6wEznID1mPT+48ZnP2nkHzgjpL4kroYHg0CdqJ5cTXk+UO5znAxF5fRUkhdyfgrhh8Lzw==",
       "requires": {
-        "tabbable": "^1.0.3"
+        "tabbable": "^3.1.2",
+        "xtend": "^4.0.1"
       }
     },
     "focus-trap-react": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-3.1.4.tgz",
-      "integrity": "sha512-uqMKMg9Xlny0LKHW0HqA7ncLafW57SxgeedjE7/Xt+NB7sdOBUG4eD/9sMsq1O0+7zD3palpniTs2n0PDLc3uA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-6.0.0.tgz",
+      "integrity": "sha512-mvEYxmP75PMx0vOqoIAmJHO/qUEvdTAdz6gLlEZyxxODnuKQdnKea2RWTYxghAPrV+ibiIq2o/GTSgQycnAjcw==",
       "requires": {
-        "focus-trap": "^2.0.1"
+        "focus-trap": "^4.0.2"
       }
     },
     "follow-redirects": {
@@ -14334,6 +14331,29 @@
         "focus-trap-react": "^3.0.4",
         "no-scroll": "^2.0.0",
         "react-displace": "^2.3.0"
+      },
+      "dependencies": {
+        "focus-trap": {
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-2.4.6.tgz",
+          "integrity": "sha512-vWZTPtBU6pBoyWZDRZJHkXsyP2ZCZBHE3DRVXnSVdQKH/mcDtu9S5Kz8CUDyIqpfZfLEyI9rjKJLnc4Y40BRBg==",
+          "requires": {
+            "tabbable": "^1.0.3"
+          }
+        },
+        "focus-trap-react": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-3.1.4.tgz",
+          "integrity": "sha512-uqMKMg9Xlny0LKHW0HqA7ncLafW57SxgeedjE7/Xt+NB7sdOBUG4eD/9sMsq1O0+7zD3palpniTs2n0PDLc3uA==",
+          "requires": {
+            "focus-trap": "^2.0.1"
+          }
+        },
+        "tabbable": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-1.1.3.tgz",
+          "integrity": "sha512-nOWwx35/JuDI4ONuF0ZTo6lYvI0fY0tZCH1ErzY2EXfu4az50ZyiUX8X073FLiZtmWUVlkRnuXsehjJgCw9tYg=="
+        }
       }
     },
     "react-dev-utils": {
@@ -14518,6 +14538,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
     "react-refresh": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
@@ -14659,6 +14684,17 @@
         "prop-types": "^15.6.2",
         "react-is": "^16.8.6",
         "scheduler": "^0.19.1"
+      }
+    },
+    "react-transition-group": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+      "requires": {
+        "dom-helpers": "^3.4.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
       }
     },
     "read-pkg": {
@@ -16780,9 +16816,9 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "tabbable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-1.1.3.tgz",
-      "integrity": "sha512-nOWwx35/JuDI4ONuF0ZTo6lYvI0fY0tZCH1ErzY2EXfu4az50ZyiUX8X073FLiZtmWUVlkRnuXsehjJgCw9tYg=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-3.1.2.tgz",
+      "integrity": "sha512-wjB6puVXTYO0BSFtCmWQubA/KIn7Xvajw0x0l6eJUudMG/EAiJvIUnyNX6xO4NpGrJ16lbD0eUseB9WxW0vlpQ=="
     },
     "table": {
       "version": "6.7.1",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
   },
   "homepage": "https://cmsgov.github.io/qpp-submissions-docs",
   "dependencies": {
-    "@cmsgov/design-system-core": "^3.0.0",
-    "@cmsgov/design-system-layout": "^3.7.2",
+    "@cmsgov/design-system": "2.8.0",
     "core-js": "3.15.2",
     "node-sass": "^6.0.1",
     "react": "^16.13.1",

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,5 +1,4 @@
-@import '../node_modules/@cmsgov/design-system-core/dist/index.css';
-@import '../node_modules/@cmsgov/design-system-layout/dist/index.css';
+@import '../node_modules/@cmsgov/design-system/dist/css/index.css';
 @import 'styles/vendor/bootstrap.min.css';
 @import 'styles/vendor/qpp-style';
 @import 'styles/global';


### PR DESCRIPTION
## Description
Upgrade the app to utilize the most up-to-date cms design package. Follow the [migration guide](https://design.cms.gov/startup/migrating-v2/).

## Motivation and Context
We were using two npm packages, @cmsgov/design-system-core and @cmsgov/design-system-layout, that are now deprecated and consolidated into one master design package called @cmsgov/design-system.

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-5609
