### PR TITLE
QPPA-5944: Updates reportingRate description of non-proportion measurements

### DIFF
--- a/src/app/components/references/data.ts
+++ b/src/app/components/references/data.ts
@@ -52,7 +52,7 @@ export const measurementsFields: IFields = {
     { name: 'isEndToEndReported', value: 'boolean', description: 'True if the measure was reported via certified EHR technology without any manual interference.', notes: 'writable, required' },
     { name: 'numeratorExclusion', value: 'float', description: 'The exclusions from the numerator field as described in the QCDR measure specification.', notes: 'writable, optional' },
     { name: 'denominatorException', value: 'float', description: 'The exceptions from the denominator field as described in the QCDR measure specification.', notes: 'writable, optional' },
-    { name: 'reportingRate', value: 'float', description: 'The data completeness of the measure.', notes: 'calculated by API and returned in response' },
+    { name: 'reportingRate', value: 'float', description: 'The reporting rate, ranging from zero to one-hundred and representing a percentage, is equal to ((observationInstances + denominatorException + numeratorExclusion) / denominator) * 100. This is also referred to as data completeness.', notes: 'calculated by API and returned in response' },
     { name: 'observationInstances', value: 'integer', description: 'The number of denominator eligible instances that are used as input in the calculation to derive the numerator (i.e. average, ratio).', notes: 'writable, required' },
   ],
   singlePerformanceRate: [

--- a/src/app/components/references/measurements.tsx
+++ b/src/app/components/references/measurements.tsx
@@ -7,7 +7,7 @@ import envConfig from '../../../envConfig';
 const Measurements = () => {
   return (
     <>
-      <p className='qpp-docs-page-updated'>Last Updated: 06/04/2021</p> {/* IMPORTANT: update this Last-Updated value if you have made any changes to this page's content. */}
+      <p className='qpp-docs-page-updated'>Last Updated: 01/21/2022</p> {/* IMPORTANT: update this Last-Updated value if you have made any changes to this page's content. */}
       <h2 className='ds-h2' style={{marginTop: 0}}>Measurements</h2>
       <ul>
         {Object.entries(measurementsTitleAndId).map(([title, id], i) =>


### PR DESCRIPTION
## Description
Adds calculation for reportingRate to the Description for the Non-Proportion Measurements.

https://cmsgov.github.io/qpp-submissions-docs/measurements#non-proportion-measurements

The reporting rate, ranging from zero to one-hundred and representing a percentage, is equal to 100 * ( ( observationInstances + denominatorException + numeratorExclusion ) / denominator ). This is also referred to as data completeness.

## Motivation and Context
- This change includes a more detailed description of the reporting rate by including the API-side calculation of the metric.
- This change creates more consistency with the description provided in other measurement types (eg. Single-Performance Rate and Multi-Performance Rate)

## Screenshot:
![image](https://user-images.githubusercontent.com/74992804/150570503-43f6c1fc-8837-4dc1-b17b-a62ece3ba1bb.png)

## Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have updated the Last-Updated value on all documentation pages where I changed content.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.

## Jira Ticket:
https://jira.cms.gov/browse/QPPA-5994
