### PR TITLE
QPPA-0000: Adds fontawesome package so qpp-style loads font family correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@cmsgov/design-system": "2.8.0",
         "@vitejs/plugin-react": "4.2.1",
         "core-js": "3.31.1",
+        "font-awesome": "4.7.0",
         "postcss": "8.4.31",
         "react": "^16.13.1",
         "react-code-blocks": "0.1.2",
@@ -4468,6 +4469,14 @@
       "peerDependencies": {
         "react": "0.14.x || ^15.0.0 || ^16.0.0",
         "react-dom": "0.14.x || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/font-awesome": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "integrity": "sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg==",
+      "engines": {
+        "node": ">=0.10.3"
       }
     },
     "node_modules/for-each": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@cmsgov/design-system": "2.8.0",
     "@vitejs/plugin-react": "4.2.1",
     "core-js": "3.31.1",
+    "font-awesome": "4.7.0",
     "postcss": "8.4.31",
     "react": "^16.13.1",
     "react-code-blocks": "0.1.2",

--- a/src/styles/_global.scss
+++ b/src/styles/_global.scss
@@ -1,4 +1,5 @@
 @import './variables';
+@import 'font-awesome/css/font-awesome.min.css';
 
 body {
   margin: 0;


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs when possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation.
-->

## Related Tickets & Documents
<!--
Mandatory if the ticket exists. Otherwise, the description section **must** contain the details.
-->

---

## Description
Adds fontawesome package so qpp-style loads font family correctly. This was a necessary change after vite upgrade.

---
## What type of PR is this?
<!--
(mark 'x' all applicable)
-->
- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore
- [ ] ⏩ Revert

---

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
---

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Confluence
- [x] 🙅 no documentation needed